### PR TITLE
Add confirmation for settings reset and preserve API keys

### DIFF
--- a/src/settings-bundled.js
+++ b/src/settings-bundled.js
@@ -64,16 +64,16 @@ async function retrieveApiKey(keyName) {
         const result = await chrome.storage.local.get(keyName);
         const encrypted = result[keyName];
         if (!encrypted) return null;
-        
+
         const combined = new Uint8Array(atob(encrypted).split('').map(c => c.charCodeAt(0)));
         const salt = combined.slice(0, 16);
         const iv = combined.slice(16, 28);
         const encryptedData = combined.slice(28);
-        
+
         const password = await getEncryptionPassword();
         const key = await deriveKey(password, salt);
         const decryptedData = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv }, key, encryptedData);
-        
+
         const decoder = new TextDecoder();
         return decoder.decode(decryptedData);
     } catch (error) {
@@ -114,18 +114,18 @@ async function loadSettings() {
     ]);
     const settings = result[STORAGE_KEYS.USER_SETTINGS] || getDefaultSettings();
     settings.selectedProvider = result[STORAGE_KEYS.SELECTED_PROVIDER] || 'openai';
-    
+
     const openaiKey = await retrieveApiKey(STORAGE_KEYS.OPENAI_API_KEY);
     const geminiKey = await retrieveApiKey(STORAGE_KEYS.GEMINI_API_KEY);
     settings.hasOpenAIKey = !!openaiKey;
     settings.hasGeminiKey = !!geminiKey;
-    
+
     return settings;
 }
 
 async function saveSettings(settings) {
     const { openaiApiKey, geminiApiKey, selectedProvider, ...otherSettings } = settings;
-    
+
     if (selectedProvider) {
         await chrome.storage.local.set({ [STORAGE_KEYS.SELECTED_PROVIDER]: selectedProvider });
     }
@@ -150,10 +150,10 @@ function validateSettings(settings) {
 }
 
 async function resetSettings() {
-    // Keep API keys, reset everything else
+    // Keep API keys and selected provider, reset everything else
     const defaults = getDefaultSettings();
     await chrome.storage.local.set({ [STORAGE_KEYS.USER_SETTINGS]: defaults });
-    await chrome.storage.local.set({ [STORAGE_KEYS.SELECTED_PROVIDER]: 'openai' });
+    // Note: We do NOT reset STORAGE_KEYS.SELECTED_PROVIDER here anymore
 }
 
 async function clearApiKey(provider) {
@@ -197,7 +197,7 @@ const contextText = document.getElementById('context-text');
 // Function to toggle API key fields based on selected provider
 function toggleApiKeyFields() {
     const selectedProvider = providerOpenAI.checked ? 'openai' : 'gemini';
-    
+
     if (selectedProvider === 'openai') {
         // Show OpenAI fields
         if (openaiKeyLabel) openaiKeyLabel.style.display = '';
@@ -238,7 +238,7 @@ function showStatus(message, isError = false) {
 
 async function updateApiKeyStatus() {
     const status = await getApiKeyStatus();
-    
+
     if (status.hasOpenAI) {
         openaiStatus.textContent = '✓ Key configured';
         openaiStatus.className = 'hint success-text';
@@ -250,7 +250,7 @@ async function updateApiKeyStatus() {
         clearOpenAIBtn.style.display = 'none';
         openaiKeyInput.placeholder = 'Your OpenAI Key...';
     }
-    
+
     if (status.hasGemini) {
         geminiStatus.textContent = '✓ Key configured';
         geminiStatus.className = 'hint success-text';
@@ -267,7 +267,7 @@ async function updateApiKeyStatus() {
 async function loadCurrentSettings() {
     try {
         const settings = await loadSettings();
-        
+
         if (settings.detailLevel === 'comprehensive') {
             detailComprehensive.checked = true;
         } else if (settings.detailLevel === 'concise') {
@@ -275,17 +275,17 @@ async function loadCurrentSettings() {
         } else {
             detailNormal.checked = true;
         }
-        
+
         if (settings.downloadOption === 'favorites') {
             downloadFavorites.checked = true;
         } else {
             downloadAll.checked = true;
         }
-        
+
         if (settings.contextInstructions) {
             contextText.value = settings.contextInstructions;
         }
-        
+
         // Set the screenshot mode radio button
         const screenshotViewport = document.getElementById('screenshot-viewport');
         const screenshotFullpage = document.getElementById('screenshot-fullpage');
@@ -296,7 +296,7 @@ async function loadCurrentSettings() {
             screenshotViewport.checked = true;
             screenshotFullpage.checked = false;
         }
-        
+
         // Set the selected provider radio button
         if (settings.selectedProvider === 'gemini') {
             providerGemini.checked = true;
@@ -305,7 +305,7 @@ async function loadCurrentSettings() {
             providerOpenAI.checked = true;
             providerGemini.checked = false;
         }
-        
+
         await updateApiKeyStatus();
         toggleApiKeyFields(); // Show/hide fields based on selected provider
     } catch (error) {
@@ -316,44 +316,44 @@ async function loadCurrentSettings() {
 
 async function handleSubmit(event) {
     event.preventDefault();
-    
+
     try {
         const formData = new FormData(form);
         const settings = {};
-        
+
         const detailLevel = formData.get('detail');
         if (detailLevel) settings.detailLevel = detailLevel;
-        
+
         const downloadOption = formData.get('download');
         if (downloadOption) settings.downloadOption = downloadOption;
-        
+
         const screenshotMode = formData.get('screenshot');
         if (screenshotMode) settings.screenshotMode = screenshotMode;
-        
+
         settings.contextInstructions = formData.get('context') || '';
         settings.selectedProvider = formData.get('provider') || 'openai';
-        
+
         const openaiKey = openaiKeyInput.value.trim();
         const geminiKey = geminiKeyInput.value.trim();
-        
+
         if (openaiKey && openaiKey !== '••••••••••••••••') {
             settings.openaiApiKey = openaiKey;
         }
         if (geminiKey && geminiKey !== '••••••••••••••••') {
             settings.geminiApiKey = geminiKey;
         }
-        
+
         const validation = validateSettings(settings);
         if (!validation.valid) {
             showStatus(`Validation errors: ${validation.errors.join(', ')}`, true);
             return;
         }
-        
+
         await saveSettings(settings);
-        
+
         openaiKeyInput.value = '';
         geminiKeyInput.value = '';
-        
+
         await updateApiKeyStatus();
         showStatus('Settings saved successfully!');
     } catch (error) {
@@ -406,20 +406,35 @@ if (shortcutsBtn) {
 
 // Add event listener for reset settings button
 const resetBtn = document.getElementById('reset-settings');
-if (resetBtn) {
-    resetBtn.addEventListener('click', async () => {
-        if (confirm('Reset all settings to defaults? (API keys will not be affected)')) {
+const resetDialog = document.getElementById('reset-warning-dialog');
+const confirmResetBtn = document.getElementById('confirm-reset-action');
+const cancelResetBtn = document.getElementById('cancel-reset-action');
+
+if (resetBtn && resetDialog) {
+    resetBtn.addEventListener('click', () => {
+        resetDialog.showModal();
+    });
+
+    if (confirmResetBtn) {
+        confirmResetBtn.addEventListener('click', async () => {
             try {
                 await resetSettings();
                 showStatus('Settings reset to defaults');
                 // Reload settings to update UI
                 await loadCurrentSettings();
+                resetDialog.close();
             } catch (error) {
                 console.error('Error resetting settings:', error);
                 showStatus('Failed to reset settings', true);
             }
-        }
-    });
+        });
+    }
+
+    if (cancelResetBtn) {
+        cancelResetBtn.addEventListener('click', () => {
+            resetDialog.close();
+        });
+    }
 }
 
 loadCurrentSettings();

--- a/src/settings.html
+++ b/src/settings.html
@@ -14,17 +14,17 @@
     <header>
         <h1 class="sr-only">Sense UI</h1>
         <nav>
-        <a href="index.html">Chat</a>
-        <br>
-        <a href="settings.html" aria-current="page">Settings</a>
-        <br>
-        <a href="about.html">About</a>
-    </nav>
+            <a href="index.html">Chat</a>
+            <br>
+            <a href="settings.html" aria-current="page">Settings</a>
+            <br>
+            <a href="about.html">About</a>
+        </nav>
     </header>
 
     <main id="main">
-            <h1>Settings</h1>
-            <p>Configure your API keys and customize SenseUI's behavior and responses.</p>
+        <h1>Settings</h1>
+        <p>Configure your API keys and customize SenseUI's behavior and responses.</p>
 
         <section>
             <form id="settings-form" novalidate>
@@ -33,12 +33,14 @@
                 <fieldset id="api-fieldset" aria-labelledby="api-legend">
                     <legend id="api-legend">Enter your API key to use SenseUI</legend>
                     <h3>How to get an API key</h3>
-                    <p>You can visit these links (opens in a new tab). If you already have one, continue to the next step.</p>
+                    <p>You can visit these links (opens in a new tab). If you already have one, continue to the next
+                        step.</p>
                     <ul>
                         <li><a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">
                                 Get your OpenAI API key
                             </a></li>
-                        <li><a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noopener">Get your Google Gemini API key</a></li>
+                        <li><a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noopener">Get your
+                                Google Gemini API key</a></li>
                     </ul>
                     <br>
                     <!-- AI provider selection -->
@@ -82,13 +84,17 @@
                     <legend id="screenshot-legend">Choose which part of the page to capture for analysis.</legend>
                     <br>
                     <label for="screenshot-viewport">
-                        <input id="screenshot-viewport" type="radio" name="screenshot" value="viewport" checked aria-checked="true">
-                        Viewport only (default) — Captures only what's visible on screen (faster feedback, less tokens, more details)
+                        <input id="screenshot-viewport" type="radio" name="screenshot" value="viewport" checked
+                            aria-checked="true">
+                        Viewport only (default) — Captures only what's visible on screen (faster feedback, less tokens,
+                        more details)
                     </label>
                     <br>
                     <label for="screenshot-fullpage">
-                        <input id="screenshot-fullpage" type="radio" name="screenshot" value="fullpage" aria-checked="false">
-                        Full page — Captures entire page length (slower, more tokens, not ideal for infinite scroll pages or heavy dynamic content)
+                        <input id="screenshot-fullpage" type="radio" name="screenshot" value="fullpage"
+                            aria-checked="false">
+                        Full page — Captures entire page length (slower, more tokens, not ideal for infinite scroll
+                        pages or heavy dynamic content)
                     </label>
                 </fieldset>
                 <br>
@@ -158,13 +164,25 @@
                 <!-- Keyboard Shortcut Section -->
                 <h2>Keyboard Shortcut</h2>
                 <p>You can customize the keyboard shortcut to open/close SenseUI.</p>
-                <button type="button" id="open-shortcuts" class="btn-secondary">Change keyboard shortcut<span class="sr-only"> (opens the browser's extension manager in new tab)</span></button>
+                <button type="button" id="open-shortcuts" class="btn-secondary">Change keyboard shortcut<span
+                        class="sr-only"> (opens the browser's extension manager in new tab)</span></button>
                 <br>
                 <br>
                 <!-- End Keyboard Shortcut Section -->
-                    <button type="submit" id="save-settings" class="btn-primary">Save</button>
-                    <br>
-                    <button type="button" style="margin-top: 1rem;" id="reset-settings" class="btn-secondary">Reset to Defaults</button>
+
+                <dialog id="reset-warning-dialog">
+                    <h3>Warning</h3>
+                    <p tabindex="0">Are you sure you want to reset all preferences to defaults? API keys and provider
+                        selection will be preserved.</p>
+                    <div class="dialog-actions">
+                        <button type="button" id="cancel-reset-action" class="btn-secondary">Cancel</button>
+                        <button type="button" id="confirm-reset-action" class="btn-primary">Confirm</button>
+                    </div>
+                </dialog>
+                <button type="submit" id="save-settings" class="btn-primary">Save</button>
+                <br>
+                <button type="button" style="margin-top: 1rem;" id="reset-settings" class="btn-secondary">Reset to
+                    Defaults</button>
                 <!-- Status area for screen readers (updated via script on submit) -->
                 <div id="settings-status" role="status" aria-live="polite" class="visually-hidden" aria-atomic="true">
                 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,9 +24,11 @@ body {
 
 main {
     padding: 2vh 5vw;
-    max-width: 450px; /* Match html width constraint */
+    max-width: 450px;
+    /* Match html width constraint */
     margin: 0 auto;
-    max-height: 600px; /* Match html height constraint */
+    max-height: 600px;
+    /* Match html height constraint */
 }
 
 /* skip link: hidden visually, visible when focused */
@@ -77,6 +79,7 @@ nav a {
     margin-bottom: 0.5rem;
     display: inline-block;
 }
+
 nav a[aria-current="page"] {
     text-decoration: underline;
     color: var(--primary-color);
@@ -121,7 +124,8 @@ h3 {
 
 h4 {
     font-weight: 600;
-    font-size: 1.125rem;}
+    font-size: 1.125rem;
+}
 
 h5 {
     font-weight: 400;
@@ -174,7 +178,8 @@ li {
 }
 
 
-.chat-input-area, .buttons-container {
+.chat-input-area,
+.buttons-container {
     display: flex;
     padding: 1vh 5vw;
     width: auto;
@@ -207,6 +212,7 @@ li {
     font-size: 1rem;
     cursor: pointer;
 }
+
 .btn-secondary {
     padding: 0.5rem;
     background: var(--secondary-color);
@@ -241,4 +247,35 @@ li {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+}
+
+/* Dialog Styles */
+#reset-warning-dialog {
+    background-color: var(--background-color);
+    color: white;
+    border: 1px solid var(--secondary-color);
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 400px;
+}
+
+#reset-warning-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.7);
+}
+
+#reset-warning-dialog h3 {
+    margin-top: 0;
+    color: var(--primary-color);
+}
+
+#reset-warning-dialog p[tabindex="0"]:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+#reset-warning-dialog .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 20px;
 }


### PR DESCRIPTION
This PR improves the "Reset to Defaults" functionality by adding a confirmation dialog and ensuring that critical user authentication data (API keys and selected provider) is preserved during a reset. 
## Changes

- **Settings Page ([settings.html](
  - Added a native `<dialog>` element for the reset confirmation.
  - Added accessibility support (`tabindex="0"`) to the warning message for keyboard navigation.
- **Logic (`settings.js`):**
  - Updated [resetSettings()](
-  to preserve the currently selected AI provider (in addition to API keys).)
- **Styles ([styles.css](
  - Added dark-theme compatible styles for the new reset dialog.
  - Added focus indicators for accessibility.
  )
## Motivation
Previously, resetting settings could accidentally wipe the user's selected provider, and the confirmation experience was not styled. This change ensures users don't lose their authentication setup while resetting preferences, and provides a safer, more integrated UI.
## Testing
1. Navigate to Settings.

2. Click "Reset to Defaults" and verify the custom warning dialog appears.
3. Confirm the reset and verify that:
   - Preferences (like detail level) are reset.
   - API Keys and the selected Provider are **not** reset.